### PR TITLE
The desktop file should not use an absolute path for the icon file

### DIFF
--- a/build/Linux/pencil.desktop
+++ b/build/Linux/pencil.desktop
@@ -8,6 +8,6 @@ Exec=/usr/bin/pencil
 Terminal=false
 Type=Application
 StartupNotify=true
-Icon=/usr/share/evolus-pencil/skin/classic/icon.svg
+Icon=pencil.svg
 Categories=Graphics;2DGraphics;Development;
 MimeType=application/ep;


### PR DESCRIPTION
I am working on new packages in the OpenSuse repositories.
This change will improve the packaging in an RPM.
See https://build.opensuse.org/package/show/home:m_vanderwulp:branches:graphics/pencil.
