### PR TITLE
make pencil load an ep file by clicking on it or when given in a shell

### DIFF
--- a/build/Linux/pencil
+++ b/build/Linux/pencil
@@ -13,7 +13,7 @@ for BIN in $BINARIES; do
     BIN_PATH=$(which ${BIN} 2>/dev/null)
 
     if [ "$?" == "0" ]; then
-        OPTS="${APP_INI}" "$@"
+        OPTS="${APP_INI} $@"
 
         if [ "${BIN}" != "xulrunner" ]; then
             OPTS="--app ${OPTS}"


### PR DESCRIPTION
This patch solves a very important issue for Pencil!
1. This little change makes typing this on a linux command line work: 
   pencil test1.ep
   Before this change, you just got an error:
     /usr/bin/pencil: line 16: test1.ep: command not found
     Incorrect number of arguments passed to -app
2. This little change makes clicking on a test1.ep file in the filemanager (Dolphin on KDE in my case) open pencil with this file.
   Before this change, it did nothing
